### PR TITLE
Add a command to copy the relative filepath + line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,16 @@ The extension is very useful for giving rspec (or a different unit test runner) 
 
 <img width="1624" alt="Screenshot 2022-11-25 at 1 56 59 AM" src="https://user-images.githubusercontent.com/1789832/203859452-a7bdf842-93e0-438d-95fc-89da1b199608.png">
 
+## Usage 
+
+- Press `Alt + l` (`Ctrl + l` on MacOS) to copy the current file's **full** path and current line number
+- Press `Alt + Shift + l` (`Ctrl +  Shift + l` on MacOS) to copy the current file's **relative** path and current line number
+
 
 ## Install
 
 Visit https://marketplace.visualstudio.com/items?itemName=nisanthchunduru.copy-filepath-with-line-number and click the "Install" button
 
-Press Alt + l (Ctrl + l on MacOS) to copy the current file's path and current line number
 
 ### Install from source
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onCommand:copy-filepath-with-line-number"
+		"onCommand:copy-filepath-with-line-number",
+		"onCommand:copy-relative-filepath-with-line-number"
 	],
 	"main": "./main.js",
 	"contributes": {
@@ -38,6 +39,10 @@
 			{
 				"command": "copy-filepath-with-line-number",
 				"title": "Copy current file full path with current line number"
+			},
+			{
+				"command": "copy-relative-filepath-with-line-number",
+				"title": "Copy current relative file path with current line number"
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -33,6 +33,12 @@
 				"key": "alt+l",
 				"mac": "ctrl+l",
 				"when": "editorTextFocus"
+			},
+			{
+				"command": "copy-relative-filepath-with-line-number",
+				"key": "alt+shift+l",
+				"mac": "ctrl+shift+l",
+				"when": "editorTextFocus"
 			}
 		],
 		"commands": [


### PR DESCRIPTION
Adds a command to copy the current relative filepath + line number.


- Leverages the existing function to copy the full file path + line number by adding an optional `relative` paramater, that will instead copy the relative path instead of the full FS path
- Adds the new command `copy-relative-filepath-with-line-number`
- Adds a shortcut of `ctrl+shift+L` for the command